### PR TITLE
Remove the dependency on the kubernetes client

### DIFF
--- a/vertx-config-kubernetes-configmap/pom.xml
+++ b/vertx-config-kubernetes-configmap/pom.xml
@@ -21,37 +21,14 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-server-mock</artifactId>
-      <version>2.2.13</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp</artifactId>
-      <version>3.6.0</version>
+      <version>2.6.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>
-      <artifactId>kubernetes-client</artifactId>
-      <version>${kubernetes-client-version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.fasterxml.jackson.module</groupId>
-          <artifactId>jackson-module-jaxb-annotations</artifactId>
-        </exclusion>
-      </exclusions>
+      <artifactId>openshift-server-mock</artifactId>
+      <version>2.6.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
@@ -71,6 +48,10 @@
       <artifactId>jackson-module-jaxb-annotations</artifactId>
       <!-- MUST match the imported version -->
       <version>2.7.4</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
     </dependency>
 
     <dependency>

--- a/vertx-config-kubernetes-configmap/pom.xml
+++ b/vertx-config-kubernetes-configmap/pom.xml
@@ -44,12 +44,6 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.module</groupId>
-      <artifactId>jackson-module-jaxb-annotations</artifactId>
-      <!-- MUST match the imported version -->
-      <version>2.7.4</version>
-    </dependency>
-    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-web-client</artifactId>
     </dependency>

--- a/vertx-config-kubernetes-configmap/src/main/java/io/vertx/config/kubernetes/ConfigMapStore.java
+++ b/vertx-config-kubernetes-configmap/src/main/java/io/vertx/config/kubernetes/ConfigMapStore.java
@@ -136,7 +136,7 @@ public class ConfigMapStore implements ConfigStore {
           .putHeader("Authorization", "Bearer " + token)
           .send(ar -> {
             if (ar.failed()) {
-              completionHandler.handle(Future.failedFuture(ar.cause()));
+              completionHandler.handle(ar.mapEmpty());
               return;
             }
             HttpResponse<Buffer> response = ar.result();

--- a/vertx-config-kubernetes-configmap/src/main/java/io/vertx/config/kubernetes/ConfigMapStore.java
+++ b/vertx-config-kubernetes-configmap/src/main/java/io/vertx/config/kubernetes/ConfigMapStore.java
@@ -1,11 +1,5 @@
 package io.vertx.config.kubernetes;
 
-import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.client.Config;
-import io.fabric8.kubernetes.client.ConfigBuilder;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.vertx.config.spi.ConfigStore;
 import io.vertx.config.spi.utils.JsonObjectHelper;
 import io.vertx.core.AsyncResult;
@@ -14,6 +8,9 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.client.HttpResponse;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.WebClientOptions;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,7 +29,9 @@ public class ConfigMapStore implements ConfigStore {
   private final String key;
   private final boolean secret;
   private final boolean optional;
-  private KubernetesClient client;
+
+  private final WebClient client;
+  private String token;
 
 
   public ConfigMapStore(Vertx vertx, JsonObject configuration) {
@@ -51,120 +50,142 @@ public class ConfigMapStore implements ConfigStore {
     this.name = configuration.getString("name");
     this.key = configuration.getString("key");
     this.secret = configuration.getBoolean("secret", false);
-    Objects.requireNonNull(this.name);
-  }
+    int port = configuration.getInteger("port", 0);
+    if (port == 0) {
+      if (configuration.getBoolean("ssl", true)) {
+        port = 443;
+      } else {
+        port = 80;
+      }
+    }
 
-  /**
-   * For testing purpose only - inject the kubernetes client.
-   *
-   * @param client the client.
-   */
-  synchronized void setClient(KubernetesClient client) {
-    this.client = client;
+    String p = System.getenv("KUBERNETES_SERVICE_PORT");
+    if (p != null) {
+      port = Integer.valueOf(p);
+    }
+
+    String host = configuration.getString("host");
+    String h = System.getenv("KUBERNETES_SERVICE_HOST");
+    if (h != null) {
+      host = h;
+    }
+
+    client = WebClient.create(vertx,
+      new WebClientOptions()
+        .setTrustAll(true)
+        .setSsl(configuration.getBoolean("ssl", true))
+        .setDefaultHost(host)
+        .setDefaultPort(port)
+        .setFollowRedirects(true)
+    );
+
+    Objects.requireNonNull(this.name);
   }
 
   @Override
   public synchronized void close(Handler<Void> completionHandler) {
     if (client != null) {
       client.close();
-      client = null;
     }
   }
 
-  private Future<KubernetesClient> getClient() {
-    Future<KubernetesClient> result = Future.future();
-    String master = configuration.getString("master", KubernetesUtils.getDefaultKubernetesMasterUrl());
-    vertx.<KubernetesClient>executeBlocking(future -> {
-      try {
-        String accountToken = configuration.getString("token");
-        if (accountToken == null) {
-          accountToken = KubernetesUtils.getTokenFromFile();
-        }
 
-        Config config = new ConfigBuilder().withOauthToken(accountToken).withMasterUrl(master).withTrustCerts(true)
-          .build();
+  private Future<String> getToken() {
+    Future<String> result = Future.future();
 
-        DefaultKubernetesClient kubernetesClient = new DefaultKubernetesClient(config);
-        future.complete(kubernetesClient);
-      } catch (Exception e) {
-        future.fail(e);
-      }
-    }, ar -> {
+    String token = configuration.getString("token");
+    if (token != null && !token.trim().isEmpty()) {
+      this.token = token;
+      result.complete(token);
+      return result;
+    }
+
+    // Read from file
+    vertx.fileSystem().readFile(KubernetesUtils.OPENSHIFT_KUBERNETES_TOKEN_FILE, ar -> {
       if (ar.failed()) {
-        result.fail(ar.cause());
+        result.tryFail(ar.cause());
       } else {
-        this.client = ar.result();
-        result.complete(ar.result());
+        this.token = ar.result().toString();
+        result.tryComplete(ar.result().toString());
       }
     });
+
     return result;
   }
 
   @Override
   public synchronized void get(Handler<AsyncResult<Buffer>> completionHandler) {
-    Future<KubernetesClient> retrieveClient;
-    if (client == null) {
-      retrieveClient = getClient();
+    Future<String> retrieveToken;
+    if (token == null) {
+      retrieveToken = getToken();
     } else {
-      retrieveClient = Future.succeededFuture(client);
+      retrieveToken = Future.succeededFuture(token);
     }
 
-    retrieveClient.compose(client -> {
-      Future<Buffer> json = Future.future();
-      vertx.executeBlocking(
-        future -> {
-          if (secret) {
-            Secret secret = client.secrets().inNamespace(namespace).withName(name).get();
-            if (secret == null) {
-              future.fail("Cannot find the config map '" + name + "' in '" + namespace + "'");
-            } else {
-              if (this.key == null) {
-                Map<String, Object> cm = asObjectMap(secret.getData());
-                future.complete(Buffer.buffer(new JsonObject(cm).encode()));
-              } else {
-                String value = secret.getData().get(this.key);
-                if (value == null) {
-                  future.fail("cannot find key '" + this.key + "' in the secret '" + this.name + "'");
-                } else {
-                  future.complete(Buffer.buffer(value));
-                }
-              }
+    retrieveToken
+      .compose(token -> {
+        String path = "/api/v1/namespaces/" + namespace;
+        if (secret) {
+          path += "/secrets/" + name;
+        } else {
+          path += "/configmaps/" + name;
+        }
+
+        Future<Buffer> future = Future.future();
+        client.get(path)
+          .putHeader("Authorization", "Bearer " + token)
+          .send(ar -> {
+            if (ar.failed()) {
+              completionHandler.handle(Future.failedFuture(ar.cause()));
+              return;
             }
-          } else {
-            ConfigMap map = client.configMaps().inNamespace(namespace).withName(name).get();
-            if (map == null) {
+            HttpResponse<Buffer> response = ar.result();
+            if (response.statusCode() == 404) {
               if (optional) {
                 future.complete(Buffer.buffer("{}"));
               } else {
                 future.fail("Cannot find the config map '" + name + "' in '" + namespace + "'");
               }
-            } else {
-              if (this.key == null) {
-                Map<String, Object> cm = asObjectMap(map.getData());
-                future.complete(Buffer.buffer(new JsonObject(cm).encode()));
+            } else if (response.statusCode() == 403) {
+              completionHandler.handle(Future.failedFuture("Access denied to configmap or secret in namespace "
+                + namespace + ": " + name));
+            } else if (response.statusCode() != 200) {
+              if (optional) {
+                future.complete(Buffer.buffer("{}"));
               } else {
-                String value = map.getData().get(this.key);
-                if (value == null) {
-                  future.fail("cannot find key '" + this.key + "' in the config map '" + this.name + "'");
+                completionHandler.handle(Future.failedFuture("Cannot retrieve the configmap or secret in namespace "
+                  + namespace + ": " + name + ", status code: " + response.statusCode() + ", error: "
+                  + response.bodyAsString()));
+              }
+            } else {
+              JsonObject data = response.bodyAsJsonObject().getJsonObject("data");
+              if (data == null) {
+                future.fail("Invalid secret of configmap in namespace " + namespace + " " + name + ", the data " +
+                  "entry is empty");
+                return;
+              }
+              if (this.key == null) {
+                future.complete(new JsonObject(asObjectMap(data.getMap())).toBuffer());
+              } else {
+                String string = data.getString(this.key);
+                if (string == null) {
+                  future.fail("Cannot find key '" + this.key + "' in the configmap or secret '" + this.name + "'");
                 } else {
-                  future.complete(Buffer.buffer(value));
+                  future.complete(Buffer.buffer(string));
                 }
               }
             }
-          }
-        },
-        json.completer()
-      );
-      return json;
-    }).setHandler(completionHandler);
+          });
+        return future;
+      }).setHandler(completionHandler);
   }
 
-  private static Map<String, Object> asObjectMap(Map<String, String> source) {
+  private static Map<String, Object> asObjectMap(Map<String, Object> source) {
     if (source == null) {
       return new HashMap<>();
     }
     return source.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
-      entry -> JsonObjectHelper.convert(entry.getValue())));
+      entry -> JsonObjectHelper.convert(entry.getValue().toString())));
   }
 
 }

--- a/vertx-config-kubernetes-configmap/src/main/java/io/vertx/config/kubernetes/KubernetesUtils.java
+++ b/vertx-config-kubernetes-configmap/src/main/java/io/vertx/config/kubernetes/KubernetesUtils.java
@@ -1,7 +1,5 @@
 package io.vertx.config.kubernetes;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -13,45 +11,7 @@ import java.io.InputStream;
 public class KubernetesUtils {
 
 
-  private static final String OPENSHIFT_KUBERNETES_TOKEN_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/token";
-
-  /**
-   * Computes the default master url based on the {@code KUBERNETES_SERVICE_HOST} and
-   * {@code KUBERNETES_SERVICE_PORT} environment variables
-   *
-   * @return the computed url
-   */
-  public static String getDefaultKubernetesMasterUrl() {
-    return "https://" + System.getenv().get("KUBERNETES_SERVICE_HOST")
-        + ":" + System.getenv("KUBERNETES_SERVICE_PORT");
-  }
-
-  /**
-   * Gets the token stored in the {@code /var/run/secrets/kubernetes.io/serviceaccount/token}.
-   *
-   * @return the token
-   */
-  public static String getTokenFromFile() {
-    InputStream is = null;
-    try {
-      File file = new File(OPENSHIFT_KUBERNETES_TOKEN_FILE);
-      if (! file.isFile()) {
-        throw new RuntimeException("Unable to read the token file");
-      }
-      byte[] data = new byte[(int) file.length()];
-      is = new FileInputStream(file);
-      int count = is.read(data);
-      if (count <= 0) {
-        return null;
-      } else {
-        return new String(data);
-      }
-    } catch (IOException e) {
-      throw new RuntimeException("Could not get token file", e);
-    } finally {
-      closeQuietly(is);
-    }
-  }
+  public static final String OPENSHIFT_KUBERNETES_TOKEN_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/token";
 
   private static void closeQuietly(InputStream is) {
     if (is != null) {

--- a/vertx-config-kubernetes-configmap/src/test/java/io/vertx/config/kubernetes/ConfigMapStoreOpenShiftTest.java
+++ b/vertx-config-kubernetes-configmap/src/test/java/io/vertx/config/kubernetes/ConfigMapStoreOpenShiftTest.java
@@ -1,0 +1,87 @@
+package io.vertx.config.kubernetes;
+
+import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
+import io.fabric8.openshift.client.server.mock.OpenShiftMockServer;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author <a href="http://escoffier.me">Clement Escoffier</a>
+ */
+@RunWith(VertxUnitRunner.class)
+public class ConfigMapStoreOpenShiftTest extends ConfigMapStoreTest {
+
+  @Before
+  public void setUp(TestContext tc) throws MalformedURLException {
+    vertx = Vertx.vertx();
+    vertx.exceptionHandler(tc.exceptionHandler());
+
+    ConfigMap map1 = new ConfigMapBuilder().withMetadata(new ObjectMetaBuilder().withName("my-config-map").build())
+      .addToData("my-app-json", SOME_JSON)
+      .addToData("my-app-props", SOME_PROPS)
+      .build();
+
+    Map<String, String> data = new LinkedHashMap<>();
+    data.put("key", "value");
+    data.put("bool", "true");
+    data.put("count", "3");
+    ConfigMap map2 = new ConfigMapBuilder().withMetadata(new ObjectMetaBuilder().withName("my-config-map-2").build())
+      .withData(data)
+      .build();
+
+    ConfigMap map3 = new ConfigMapBuilder().withMetadata(new ObjectMetaBuilder().withName("my-config-map-x").build())
+      .addToData("my-app-json", SOME_JSON)
+      .build();
+
+    Secret secret = new SecretBuilder().withMetadata(new ObjectMetaBuilder().withName("my-secret").build())
+      .addToData("password", "secret")
+      .build();
+
+    server = new OpenShiftMockServer(false);
+
+    server.expect().get().withPath("/api/v1/namespaces/default/configmaps").andReturn(200, new
+      ConfigMapListBuilder().addToItems(map1, map2).build()).always();
+    server.expect().get().withPath("/api/v1/namespaces/my-project/configmaps").andReturn(200, new
+      ConfigMapListBuilder().addToItems(map3).build()).always();
+
+    server.expect().get().withPath("/api/v1/namespaces/default/configmaps/my-config-map")
+      .andReturn(200, map1).always();
+    server.expect().get().withPath("/api/v1/namespaces/default/configmaps/my-config-map-2")
+      .andReturn(200, map2).always();
+
+    server.expect().get().withPath("/api/v1/namespaces/my-project/configmaps/my-config-map-x")
+      .andReturn(200, map3).always();
+
+    server.expect().get().withPath("/api/v1/namespaces/default/configmaps/my-unknown-config-map")
+      .andReturn(500, null).always();
+    server.expect().get().withPath("/api/v1/namespaces/default/configmaps/my-unknown-map")
+      .andReturn(500, null).always();
+
+    server.expect().get().withPath("/api/v1/namespaces/my-project/secrets/my-secret").andReturn(200, secret)
+      .always();
+
+    server.init();
+    client = server.createClient();
+    port = new URL(client.getConfiguration().getMasterUrl()).getPort();
+  }
+
+}


### PR DESCRIPTION
Relying on the kubernetes client didn’t bring much (except obscure issues and convoluted updates). This new version uses the Kubernetes REST API directly.