### PR TITLE
Run ConfigMapStore.get()/close() on context

### DIFF
--- a/vertx-config-kubernetes-configmap/src/main/java/io/vertx/config/kubernetes/ConfigMapStore.java
+++ b/vertx-config-kubernetes-configmap/src/main/java/io/vertx/config/kubernetes/ConfigMapStore.java
@@ -88,6 +88,10 @@ public class ConfigMapStore implements ConfigStore {
 
   @Override
   public synchronized void close(Handler<Void> completionHandler) {
+    runOnContext(v -> closeOnContext(completionHandler));
+  }
+
+  private synchronized void closeOnContext(Handler<Void> completionHandler) {
     if (client != null) {
       client.close();
     }


### PR DESCRIPTION
I'm running a `ConfigRetriever` before I deploy any Verticles in order get their configuration before I start them.

When running a `ConfigRetriever.create(vertx, configRetrieverOptions);` with a `configmap` store I see messages like
```
2017-11-14 11:21:43,012 WARN [vert.x-eventloop-thread-0] Reusing a connection with a different context: an HttpClient is probably shared between different Verticles
```
in the logs every `scanPeriod`.

A similar issue was fixed in [vertx-consul-client#35](https://github.com/vert-x3/vertx-consul-client/pull/35), and applying the same pattern to `ConfigMapStore` made the warnings go away.

I did not run the `close()` method on the context, should that be a thing?
