### PR TITLE
Kubernetes secrets are Base64-encoded

### DIFF
--- a/vertx-config-kubernetes-configmap/src/test/java/io/vertx/config/kubernetes/ConfigMapStoreOpenShiftTest.java
+++ b/vertx-config-kubernetes-configmap/src/test/java/io/vertx/config/kubernetes/ConfigMapStoreOpenShiftTest.java
@@ -18,10 +18,12 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -53,7 +55,7 @@ public class ConfigMapStoreOpenShiftTest extends ConfigMapStoreTest {
       .build();
 
     Secret secret = new SecretBuilder().withMetadata(new ObjectMetaBuilder().withName("my-secret").build())
-      .addToData("password", "secret")
+      .addToData("password", Base64.getEncoder().encodeToString("secret".getBytes(UTF_8)))
       .build();
 
     server = new OpenShiftMockServer(false);

--- a/vertx-config-kubernetes-configmap/src/test/java/io/vertx/config/kubernetes/ConfigMapStoreTest.java
+++ b/vertx-config-kubernetes-configmap/src/test/java/io/vertx/config/kubernetes/ConfigMapStoreTest.java
@@ -17,10 +17,12 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -63,7 +65,7 @@ public class ConfigMapStoreTest {
       .build();
 
     Secret secret = new SecretBuilder().withMetadata(new ObjectMetaBuilder().withName("my-secret").build())
-      .addToData("password", "secret")
+      .addToData("password", Base64.getEncoder().encodeToString("secret".getBytes(UTF_8)))
       .build();
 
     server = new KubernetesMockServer(false);


### PR DESCRIPTION
According to the [Kubernetes API docs](https://kubernetes.io/docs/api-reference/v1.8/#secret-v1-core):
> Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4

This patch decodes keys using Base64 before returning them. Tests have been updated and I've successfully ran it against our v1.7 kube cluster.

Looking at the result, I would like some input on:
* In `ConfigMapStore.get()`: Normally I wouldn't add if-statements to check for `secret` like that, but that seems to be the pattern in use. Probably time to refactor something...
* In `ConfigMapStore.asSecretObjectMap()`: The back-and-forth to `String`s seem a bit excessive
