### PR TITLE
NPE when we initialize ConfigStoreOptions with empty Json configuration

### DIFF
--- a/vertx-config/src/main/java/io/vertx/config/ConfigStoreOptions.java
+++ b/vertx-config/src/main/java/io/vertx/config/ConfigStoreOptions.java
@@ -51,7 +51,7 @@ public class ConfigStoreOptions {
   public ConfigStoreOptions(JsonObject json) {
     type = json.getString("type");
     config = json.getJsonObject("config");
-    optional = json.getBoolean("optional");
+    optional = json.getBoolean("optional", false);
     format = json.getString("format", "json");
   }
 

--- a/vertx-config/src/main/java/io/vertx/config/ConfigStoreOptions.java
+++ b/vertx-config/src/main/java/io/vertx/config/ConfigStoreOptions.java
@@ -118,6 +118,7 @@ public class ConfigStoreOptions {
   /**
    * @return whether or not the store is considered as optional. When the configuration is retrieve, if an optional store
    * returns a failure, the failure is ignored and an empty json object is used instead (for this store).
+   * The default value is false.
    */
   public boolean isOptional() {
     return optional;

--- a/vertx-config/src/test/java/io/vertx/config/ConfigStoreOptionsTest.java
+++ b/vertx-config/src/test/java/io/vertx/config/ConfigStoreOptionsTest.java
@@ -1,0 +1,27 @@
+package io.vertx.config;
+
+import io.vertx.core.json.JsonObject;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConfigStoreOptionsTest {
+
+  @Test
+  public void testDefaultConstructor() {;
+    final ConfigStoreOptions options = new ConfigStoreOptions();
+    assertThat(options.getConfig()).isEqualTo(null);
+    assertThat(options.getFormat()).isEqualTo(null);
+    assertThat(options.getType()).isEqualTo(null);
+    assertThat(options.isOptional()).isEqualTo(false);
+  }
+
+  @Test
+  public void testConstructorWithEmptyJsonConfiguration() {
+    final ConfigStoreOptions options = new ConfigStoreOptions(new JsonObject());
+    assertThat(options.getConfig()).isEqualTo(null);
+    assertThat(options.getFormat()).isEqualTo("json");
+    assertThat(options.getType()).isEqualTo(null);
+    assertThat(options.isOptional()).isEqualTo(false);
+  }
+}


### PR DESCRIPTION
Hi,

There is a bug when we set the constructor of ConfigStoreOptions with an empty Json configuration. 
A NullPointerException is thrown when auto-unboxed the `optional` configuration.

Consequently, a problem has occurred in the scala version [ConfigStoreOptions.scala](https://github.com/vert-x3/vertx-lang-scala/blob/8f6b7939dbb2fad18848dbe58a4071dd8e7b5574/vertx-lang-scala-stack/vertx-config/vertx-config/src/main/scala/io/vertx/scala/config/ConfigStoreOptions.scala) because we initialize the ConfigStoreOptions with an empty json configuration

```
def apply() = {
    new ConfigStoreOptions(new JConfigStoreOptions(emptyObj()))
}
```
I propose this fix with default value

Best Regards