### PR TITLE
Use AtomicReference in EventBusConfigStore instead of synchronization

### DIFF
--- a/vertx-config/src/main/java/io/vertx/config/impl/spi/JsonConfigStore.java
+++ b/vertx-config/src/main/java/io/vertx/config/impl/spi/JsonConfigStore.java
@@ -17,13 +17,12 @@
 
 package io.vertx.config.impl.spi;
 
-import io.vertx.config.spi.utils.JsonObjectHelper;
+import io.vertx.config.spi.ConfigStore;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonObject;
-import io.vertx.config.spi.ConfigStore;
 
 /**
  * An implementation of configuration store just retrieving the passed json object.
@@ -44,7 +43,7 @@ public class JsonConfigStore implements ConfigStore {
     if (config == null) {
       completionHandler.handle(Future.failedFuture("no configuration"));
     } else {
-      completionHandler.handle(Future.succeededFuture(JsonObjectHelper.toBuffer(config)));
+      completionHandler.handle(Future.succeededFuture(config.toBuffer()));
     }
   }
 }

--- a/vertx-config/src/main/java/io/vertx/config/spi/utils/JsonObjectHelper.java
+++ b/vertx-config/src/main/java/io/vertx/config/spi/utils/JsonObjectHelper.java
@@ -31,8 +31,14 @@ import java.util.Properties;
  */
 public class JsonObjectHelper {
 
+  /**
+   * Deprecated. {@link JsonObject} now has a {@link JsonObject#toBuffer()} method.
+   *
+   * @deprecated use {@link JsonObject#toBuffer()} instead
+   */
+  @Deprecated
   public static Buffer toBuffer(JsonObject json) {
-    return Buffer.buffer(json.encode());
+    return json.toBuffer();
   }
 
   public static void put(JsonObject json, String name, String value, boolean rawData) {


### PR DESCRIPTION
Chances are high that the event loop receiving config updates will be different than the event loop looking-up for config.
So the synchronize blocks won't be optimized away at runtime.

Also, JsonObject has a toBuffer method now