### PR TITLE
Use of "function" as parameter name causes exception in javascript as…

### DIFF
--- a/vertx-config/src/main/java/io/vertx/config/ConfigRetriever.java
+++ b/vertx-config/src/main/java/io/vertx/config/ConfigRetriever.java
@@ -110,11 +110,11 @@ public interface ConfigRetriever {
 
   /**
    * Registers a handler called before every scan. This method is mostly used for logging purpose.
-   * @param function the function, must not be {@code null}
+   * @param handler the handler, must not be {@code null}
    * @return the current config retriever
    */
   @Fluent
-  ConfigRetriever setBeforeScanHandler(Handler<Void> function);
+  ConfigRetriever setBeforeScanHandler(Handler<Void> handler);
 
   /**
    * Registers a handler that process the configuration before being injected into {@link #getConfig(Handler)} or {@link #listen(Handler)}. This allows

--- a/vertx-config/src/main/java/io/vertx/config/impl/ConfigRetrieverImpl.java
+++ b/vertx-config/src/main/java/io/vertx/config/impl/ConfigRetrieverImpl.java
@@ -207,8 +207,8 @@ public class ConfigRetrieverImpl implements ConfigRetriever {
   }
 
   @Override
-  public ConfigRetriever setBeforeScanHandler(Handler<Void> function) {
-    this.beforeScan = Objects.requireNonNull(function, "The function must not be `null`");
+  public ConfigRetriever setBeforeScanHandler(Handler<Void> handler) {
+    this.beforeScan = Objects.requireNonNull(handler, "The handler must not be `null`");
     return this;
   }
 


### PR DESCRIPTION
… it's a reserved keyword

Fixes #69 