### PR TITLE
Bug fix - hierarchical properties exception when having comments

### DIFF
--- a/vertx-config/src/main/java/io/vertx/config/impl/spi/PropertiesConfigProcessor.java
+++ b/vertx-config/src/main/java/io/vertx/config/impl/spi/PropertiesConfigProcessor.java
@@ -116,6 +116,12 @@ public class PropertiesConfigProcessor implements ConfigProcessor {
 
     private JsonObject toJson(Stream<String> stream) {
       return stream
+        .filter( line -> {
+        	line.trim();
+        	return  !line.isEmpty()
+        			&& !line.startsWith("#")
+        			&& !line.startsWith("!");
+        	})
         .map(line -> line.split("="))
         .map(raw -> {
           String property = raw[0].trim();

--- a/vertx-config/src/test/resources/file/hierarchical.properties
+++ b/vertx-config/src/test/resources/file/hierarchical.properties
@@ -1,5 +1,27 @@
+#
+# Copyright (c) 2014 Red Hat, Inc. and others
+#
+# Red Hat licenses this file to you under the Apache License, version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+#
+
+# some properties
 server.port=8080
+!# server.port=8081
+#! server.port=8081
 server.host=http://localhost
 some.double.value=1.0
+
 some.integer.values=1,2,3
+! Some comments
 single=0


### PR DESCRIPTION
Hi,

I commited a bug fix that I found while trying to use the vertx-config hierachical properties file with comments and blank lines. 
While having such properties file, vertx-config throw an exception:
io.vertx.config.impl.ConfigRetrieverImpl
SEVERE: Error while scanning configuration
java.lang.ArrayIndexOutOfBoundsException: 1

The flat properties file works fine with comments and blank line since it was implemented with the java's Properties object which already takes care of these.

The fix was to add a filter for blank lines and lines starting with either "#" or "!" (after triming spaces) inside the toJson method while using the streamer api.

Best Regards
Shlomi Muzafi