### PR TITLE
Updated the test file to match comment and blank bug fix

### DIFF
--- a/vertx-config/src/test/resources/file/hierarchical.properties
+++ b/vertx-config/src/test/resources/file/hierarchical.properties
@@ -1,5 +1,27 @@
+#
+# Copyright (c) 2014 Red Hat, Inc. and others
+#
+# Red Hat licenses this file to you under the Apache License, version 2.0
+# (the "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at:
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+#
+
+# some properties
 server.port=8080
+!# server.port=8081
+#! server.port=8081
 server.host=http://localhost
 some.double.value=1.0
+
 some.integer.values=1,2,3
+! Some comments
 single=0


### PR DESCRIPTION
I've updated the hierarchical.properties to include comments (with both "#" and "!") and blank lines in order to test the bug fix for hierarchical processor throwing an exception when having properties file with comments and/or blank lines.