### PR TITLE
Updated Zookeeper version

### DIFF
--- a/vertx-config-zookeeper/pom.xml
+++ b/vertx-config-zookeeper/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.4.10</version>
+      <version>3.4.13</version>
     </dependency>
 
     <!-- ZK requires these dependencies: declare this dependency to force vertx-config-zookeeper to use this one. These are the versions used by vert.x -->


### PR DESCRIPTION
Upgrading the vertx-kafka-client to use newer version of the native Kafka client (2.1.0) will take a conflict on Zookeeper dependency with this component.
This upgrade is needed for fixing the conflict.