### PR TITLE
Set to JsonObject.mergeIn(deep = true) for FileSet and stores

### DIFF
--- a/vertx-config-git/src/main/java/io/vertx/config/git/GitConfigStore.java
+++ b/vertx-config-git/src/main/java/io/vertx/config/git/GitConfigStore.java
@@ -188,7 +188,7 @@ public class GitConfigStore implements ConfigStore {
       } else {
         JsonObject json = new JsonObject();
         futures.stream().map(f -> (JsonObject) f.result())
-          .forEach(json::mergeIn);
+          .forEach(config -> json.mergeIn(config, true));
         result.complete(Buffer.buffer(json.encode()));
       }
     });

--- a/vertx-config-spring-config-server/src/main/java/io/vertx/config/spring/SpringConfigServerStore.java
+++ b/vertx-config-spring-config-server/src/main/java/io/vertx/config/spring/SpringConfigServerStore.java
@@ -137,7 +137,7 @@ class SpringConfigServerStore implements ConfigStore {
       for (int i = sources.size() - 1; i >= 0; i--) {
         JsonObject source = sources.getJsonObject(i);
         JsonObject content = source.getJsonObject("source");
-        configuration = configuration.mergeIn(content);
+        configuration = configuration.mergeIn(content, true);
       }
       handler.handle(Future.succeededFuture(Buffer.buffer(configuration.encode())));
     }

--- a/vertx-config/src/main/java/io/vertx/config/impl/spi/DirectoryConfigStore.java
+++ b/vertx-config/src/main/java/io/vertx/config/impl/spi/DirectoryConfigStore.java
@@ -99,7 +99,7 @@ public class DirectoryConfigStore implements ConfigStore {
               } else {
                 JsonObject json = new JsonObject();
                 futures.stream().map(f -> (JsonObject) f.result())
-                    .forEach(json::mergeIn);
+                    .forEach(config -> json.mergeIn(config, true));
                 completionHandler.handle(Future.succeededFuture(Buffer.buffer(json.encode())));
               }
             });

--- a/vertx-config/src/main/java/io/vertx/config/spi/utils/FileSet.java
+++ b/vertx-config/src/main/java/io/vertx/config/spi/utils/FileSet.java
@@ -124,7 +124,7 @@ public class FileSet {
         JsonObject result = new JsonObject();
         futures.stream()
           .map(future -> (JsonObject) future.result())
-          .forEach(result::mergeIn);
+          .forEach(config -> result.mergeIn(config, true));
         handler.handle(Future.succeededFuture(result));
       }
     });


### PR DESCRIPTION
When loading some configuration from directories with multiple files that need to be merged, the actual code only does the merge operation in the first level of the config tree, causing some unwanted side effects.

This pull request turns recursive all multi-file config merge process in master branch.