### PR TITLE
Updated Zookeeper version

### DIFF
--- a/vertx-config-zookeeper/pom.xml
+++ b/vertx-config-zookeeper/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.apache.zookeeper</groupId>
       <artifactId>zookeeper</artifactId>
-      <version>3.4.13</version>
+      <version>3.4.14</version>
     </dependency>
 
     <!-- ZK requires these dependencies: declare this dependency to force vertx-config-zookeeper to use this one. These are the versions used by vert.x -->


### PR DESCRIPTION
This PR is related to bumping the Kafka version to 2.3.0 in the Vert.x Kafka client.