### PR TITLE
[Issue-102] Added support of HTTP headers, timeout, followRedirects to Http Configuration store

### DIFF
--- a/vertx-config/src/main/asciidoc/index.adoc
+++ b/vertx-config/src/main/asciidoc/index.adoc
@@ -248,7 +248,9 @@ any supported format.
 It creates a Vert.x HTTP Client with the store configuration (see next snippet). To
 ease the configuration; you can also configure the `host`, `port` and `path` with the
 `host`, `port` and `path`
-properties.
+properties. You can also configure optional HTTP request headers with `headers` property,
+the timeout (in milliseconds, 3000 by default) to retrieve the configuration with `timeout` property,
+if following redirects (false by default) with `followRedirects` property.
 
 [source, $lang]
 ----

--- a/vertx-config/src/main/java/examples/ConfigExamples.java
+++ b/vertx-config/src/main/java/examples/ConfigExamples.java
@@ -140,7 +140,8 @@ public class ConfigExamples {
         .put("defaultHost", "localhost")
         .put("defaultPort", 8080)
         .put("ssl", true)
-        .put("path", "/A"));
+        .put("path", "/A")
+        .put("headers", new JsonObject().put("Accept", "application/json")));
   }
 
   public void eb() {

--- a/vertx-config/src/main/java/io/vertx/config/impl/spi/HttpConfigStoreFactory.java
+++ b/vertx-config/src/main/java/io/vertx/config/impl/spi/HttpConfigStoreFactory.java
@@ -18,13 +18,9 @@
 package io.vertx.config.impl.spi;
 
 import io.vertx.config.spi.ConfigStore;
-import io.vertx.core.Vertx;
-import io.vertx.core.http.HttpClient;
-import io.vertx.core.http.HttpClientOptions;
-import io.vertx.core.json.JsonObject;
 import io.vertx.config.spi.ConfigStoreFactory;
-
-import java.util.Objects;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 
 /**
  * The factory creating Json File configuration stores.
@@ -40,13 +36,6 @@ public class HttpConfigStoreFactory implements ConfigStoreFactory {
 
   @Override
   public ConfigStore create(Vertx vertx, JsonObject configuration) {
-    HttpClient client = vertx.createHttpClient(new HttpClientOptions(configuration));
-    String host = configuration.getString("host");
-    int port = configuration.getInteger("port", 80);
-    String path = configuration.getString("path", "/");
-
-    Objects.requireNonNull(host);
-
-    return new HttpConfigStore(host, port, path, client);
+    return new HttpConfigStore(vertx, configuration);
   }
 }


### PR DESCRIPTION
Fixes: #102 

* Using [RequestOptions](https://github.com/eclipse-vertx/vert.x/blob/master/src/main/java/io/vertx/core/http/RequestOptions.java) in `HttpConfigStore` so that it is possible to specify HTTP headers from the configuration.

* Introduce `headers` in the configuration
* Introduce `timeout` in the configuration
* Introduce `followRedirects` in the configuration
* Do not require the `host` in configuration, the `defaultHost` in the `HttpClientOptions` will take effect if no `host` specified in the configuration.
