### PR TITLE
Implement "raw-data" option for consul store - closes #71

### DIFF
--- a/vertx-config-consul/src/main/asciidoc/consul-store.adoc
+++ b/vertx-config-consul/src/main/asciidoc/consul-store.adoc
@@ -48,3 +48,5 @@ for further details. And this is the parameters specific to the Consul Configura
 
 `prefix`:: A prefix that will not be taken into account when building the configuration tree. Defaults to empty.
 `delimiter`:: Symbol that used to split keys in the Consul storage to obtain levels in the configuration tree. Defaults to "/".
+`raw-data`:: If `raw-data` is `true` no attempts to convert values is made, and you'll be able to get raw values using
+  `config.getString(key)`. Defaults to true.

--- a/vertx-config-consul/src/main/java/examples/ConfigConsulExamples.java
+++ b/vertx-config-consul/src/main/java/examples/ConfigConsulExamples.java
@@ -36,6 +36,7 @@ public class ConfigConsulExamples {
           .put("host", "localhost")
           .put("port", 8500)
           .put("prefix", "foo")
+          .put("raw-data", false)
         );
 
     ConfigRetriever retriever = ConfigRetriever.create(vertx,


### PR DESCRIPTION
Not sure about default value for raw-data option. "True" is backward compatible with current behaviour,  but "false" would be consistent with other stores and upcoming major version update allows intruducing some breaking changes.