### PR TITLE
Use try-with-resources statement ensures that resource is close

### DIFF
--- a/vertx-config-hocon/src/main/java/io/vertx/config/hocon/HoconProcessor.java
+++ b/vertx-config-hocon/src/main/java/io/vertx/config/hocon/HoconProcessor.java
@@ -29,7 +29,6 @@ import io.vertx.core.json.JsonObject;
 
 import java.io.Reader;
 import java.io.StringReader;
-import java.nio.charset.StandardCharsets;
 
 /**
  * A processor using Typesafe Conf to read Hocon files. It also support JSON and Properties.
@@ -50,11 +49,11 @@ public class HoconProcessor implements ConfigProcessor {
     // Indeed, HOCON resolution can read others files (includes).
     vertx.executeBlocking(
         future -> {
-          try (Reader reader = new StringReader(input.toString(StandardCharsets.UTF_8))){
+          try (Reader reader = new StringReader(input.toString("UTF-8"))) {
             Config conf = ConfigFactory.parseReader(reader);
             conf = conf.resolve();
             String output = conf.root().render(ConfigRenderOptions.concise()
-                .setJson(true).setComments(false).setFormatted(false));
+              .setJson(true).setComments(false).setFormatted(false));
             JsonObject json = new JsonObject(output);
             future.complete(json);
           } catch (Exception e) {

--- a/vertx-config-hocon/src/main/java/io/vertx/config/hocon/HoconProcessor.java
+++ b/vertx-config-hocon/src/main/java/io/vertx/config/hocon/HoconProcessor.java
@@ -29,6 +29,7 @@ import io.vertx.core.json.JsonObject;
 
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 
 /**
  * A processor using Typesafe Conf to read Hocon files. It also support JSON and Properties.
@@ -49,7 +50,7 @@ public class HoconProcessor implements ConfigProcessor {
     // Indeed, HOCON resolution can read others files (includes).
     vertx.executeBlocking(
         future -> {
-          try (Reader reader = new StringReader(input.toString())){
+          try (Reader reader = new StringReader(input.toString(StandardCharsets.UTF_8))){
             Config conf = ConfigFactory.parseReader(reader);
             conf = conf.resolve();
             String output = conf.root().render(ConfigRenderOptions.concise()

--- a/vertx-config-hocon/src/main/java/io/vertx/config/hocon/HoconProcessor.java
+++ b/vertx-config-hocon/src/main/java/io/vertx/config/hocon/HoconProcessor.java
@@ -30,8 +30,6 @@ import io.vertx.core.json.JsonObject;
 import java.io.Reader;
 import java.io.StringReader;
 
-import static io.vertx.config.impl.spi.PropertiesConfigProcessor.closeQuietly;
-
 /**
  * A processor using Typesafe Conf to read Hocon files. It also support JSON and Properties.
  * More details on Hocon and the used library on the
@@ -51,8 +49,7 @@ public class HoconProcessor implements ConfigProcessor {
     // Indeed, HOCON resolution can read others files (includes).
     vertx.executeBlocking(
         future -> {
-          Reader reader = new StringReader(input.toString("UTF-8"));
-          try {
+          try (Reader reader = new StringReader(input.toString())){
             Config conf = ConfigFactory.parseReader(reader);
             conf = conf.resolve();
             String output = conf.root().render(ConfigRenderOptions.concise()
@@ -61,8 +58,6 @@ public class HoconProcessor implements ConfigProcessor {
             future.complete(json);
           } catch (Exception e) {
             future.fail(e);
-          } finally {
-            closeQuietly(reader);
           }
         },
         handler

--- a/vertx-config-kubernetes-configmap/src/main/java/io/vertx/config/kubernetes/KubernetesUtils.java
+++ b/vertx-config-kubernetes-configmap/src/main/java/io/vertx/config/kubernetes/KubernetesUtils.java
@@ -17,16 +17,12 @@
 
 package io.vertx.config.kubernetes;
 
-import java.io.IOException;
-import java.io.InputStream;
-
 /**
  * Utility methods for Kubernetes.
  *
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
  */
 public class KubernetesUtils {
-
 
   public static final String OPENSHIFT_KUBERNETES_TOKEN_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/token";
 

--- a/vertx-config-kubernetes-configmap/src/main/java/io/vertx/config/kubernetes/KubernetesUtils.java
+++ b/vertx-config-kubernetes-configmap/src/main/java/io/vertx/config/kubernetes/KubernetesUtils.java
@@ -30,14 +30,5 @@ public class KubernetesUtils {
 
   public static final String OPENSHIFT_KUBERNETES_TOKEN_FILE = "/var/run/secrets/kubernetes.io/serviceaccount/token";
 
-  private static void closeQuietly(InputStream is) {
-    if (is != null) {
-      try {
-        is.close();
-      } catch (IOException e) {
-        // Ignore it.
-      }
-    }
-  }
 }
 

--- a/vertx-config/src/main/java/io/vertx/config/impl/spi/PropertiesConfigProcessor.java
+++ b/vertx-config/src/main/java/io/vertx/config/impl/spi/PropertiesConfigProcessor.java
@@ -28,7 +28,6 @@ import io.vertx.core.json.JsonObject;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -65,26 +64,13 @@ public class PropertiesConfigProcessor implements ConfigProcessor {
     // so the input stream is not blocking
     vertx.executeBlocking(future -> {
       byte[] bytes = input.getBytes();
-      ByteArrayInputStream stream = new ByteArrayInputStream(bytes);
-      try {
+      try (ByteArrayInputStream stream = new ByteArrayInputStream(bytes)) {
         JsonObject created = reader.readAsJson(configuration, stream);
         future.complete(created);
       } catch (Exception e) {
         future.fail(e);
-      } finally {
-        closeQuietly(stream);
       }
     }, handler);
-  }
-
-  public static void closeQuietly(Closeable closeable) {
-    if (closeable != null) {
-      try {
-        closeable.close();
-      } catch (Exception e) {
-        // Ignore it.
-      }
-    }
   }
 
   private interface PropertiesReader {


### PR DESCRIPTION
Signed-off-by: Michael Panchenko <panchmp@gmail.com>

Motivation:

Motivation:
"try-with-resources" statement should be used to ensure that resources are closed