### PR TITLE
Avoid accessing data from 2 different threads

### DIFF
--- a/vertx-config/src/main/generated/io/vertx/config/ConfigRetrieverOptionsConverter.java
+++ b/vertx-config/src/main/generated/io/vertx/config/ConfigRetrieverOptionsConverter.java
@@ -30,7 +30,7 @@ public class ConfigRetrieverOptionsConverter {
             java.util.ArrayList<io.vertx.config.ConfigStoreOptions> list =  new java.util.ArrayList<>();
             ((Iterable<Object>)member.getValue()).forEach( item -> {
               if (item instanceof JsonObject)
-                list.add(new io.vertx.config.ConfigStoreOptions((JsonObject)item));
+                list.add(new io.vertx.config.ConfigStoreOptions((io.vertx.core.json.JsonObject)item));
             });
             obj.setStores(list);
           }


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Data passed to the `process` method can be originated from a polyglot context. In this case the execute blocking will access the data from a different thread. In this case and for some languages (`js`) this is not allowed, so this PR fixes it by locking to a JVM type before entering the second thread and makes it safe.