### PR TITLE
Add missing setTransportConfigCallback() in git config store update()

### DIFF
--- a/vertx-config-git/src/main/java/io/vertx/config/git/GitConfigStore.java
+++ b/vertx-config-git/src/main/java/io/vertx/config/git/GitConfigStore.java
@@ -138,11 +138,11 @@ public class GitConfigStore implements ConfigStore {
         }
         return git;
       } else {
-        git.checkout().
-          setName(branch).
-          setUpstreamMode(CreateBranchCommand.SetupUpstreamMode.TRACK).
-          setStartPoint(remote + "/" + branch).
-          call();
+        git.checkout()
+          .setName(branch)
+          .setUpstreamMode(CreateBranchCommand.SetupUpstreamMode.TRACK)
+          .setStartPoint(remote + "/" + branch)
+          .call();
         return git;
       }
     } else {
@@ -202,7 +202,8 @@ public class GitConfigStore implements ConfigStore {
       future -> {
         PullResult call;
         try {
-          call = git.pull().setRemote(remote).setRemoteBranchName(branch).setCredentialsProvider(credentialProvider).call();
+          call = git.pull().setRemote(remote).setRemoteBranchName(branch).setCredentialsProvider(credentialProvider)
+                  .setTransportConfigCallback(transportConfigCallback).call();
         } catch (GitAPIException e) {
           future.fail(e);
           return;


### PR DESCRIPTION

When using an rsa key with vertx-config-git, I found that initial checkout works while subsequent updates fail. Further investigation led me to find this bug, where setTransportConfigCallback isn't called for the pull used in update().
