### PR TITLE
cache configuration value must be boolean instead of string

### DIFF
--- a/vertx-config/src/main/java/examples/ConfigExamples.java
+++ b/vertx-config/src/main/java/examples/ConfigExamples.java
@@ -103,7 +103,7 @@ public class ConfigExamples {
   public void sys() {
     ConfigStoreOptions json = new ConfigStoreOptions()
       .setType("sys")
-      .setConfig(new JsonObject().put("cache", "false"));
+      .setConfig(new JsonObject().put("cache", false));
   }
 
   public void env() {


### PR DESCRIPTION
Motivation:

In the example a wrong value is provided. It should be boolean instead of string.
Using the example as is results in the following exception: 
`java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Boolean`

The config store is fetching a boolean: https://github.com/vert-x3/vertx-config/blob/a572183cba302a2b7accf544c93b0855ff87e2d6/vertx-config/src/main/java/io/vertx/config/impl/spi/SystemPropertiesConfigStore.java#L44

This PR corrects the example.
