### PR TITLE
fix(): document error in vertx-config-zookeeper

### DIFF
--- a/vertx-config-zookeeper/src/main/asciidoc/zookeeper-store.adoc
+++ b/vertx-config-zookeeper/src/main/asciidoc/zookeeper-store.adoc
@@ -45,7 +45,7 @@ Once added to your classpath or dependencies, you need to configure the
 The store configuration is used to configure the Apache Curator client and the _path_ of the Zookeeper node
 containing the configuration. Notice that the format of the configuration can be JSON, or any supported format.
 
-The configuration requires the `configuration` attribute indicating the connection _string_ of the Zookeeper
+The configuration requires the `connection` attribute indicating the connection _string_ of the Zookeeper
 server, and the `path` attribute indicating the path of the node containing the configuration.
 
 In addition you can configure:


### PR DESCRIPTION
Signed-off-by: Leibniz.Hu <leibnizhu@gmail.com>

Motivation:

Document for vertx-config-zookeeper has an error.  
In code example, `ConfigStoreOptions`'s config key for zookeeper connection string is `connection`:  
```java
ConfigStoreOptions store = new ConfigStoreOptions()
    .setType("zookeeper")
    .setConfig(new JsonObject()
        .put("connection", "localhost:2181")
        .put("path", "/path/to/my/conf")
    );

ConfigRetriever retriever = ConfigRetriever.create(vertx,
    new ConfigRetrieverOptions().addStore(store));
```

But the doc below says : 
> The configuration requires the `configuration` attribute indicating the connection string of the Zookeeper server

