### PR TITLE
Preserve string representation when converting to JSON

### DIFF
--- a/vertx-config/src/main/java/io/vertx/config/impl/spi/PropertiesConfigProcessor.java
+++ b/vertx-config/src/main/java/io/vertx/config/impl/spi/PropertiesConfigProcessor.java
@@ -26,6 +26,8 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.io.*;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Properties;
 import java.util.stream.Stream;
@@ -147,11 +149,13 @@ public class PropertiesConfigProcessor implements ConfigProcessor {
       if ("false".equals(raw)) {
         return false;
       }
-      if (raw.matches("^\\d+\\.\\d+$")) {
-        return Double.parseDouble(raw);
+      try {
+        return new BigInteger(raw);
+      } catch (NumberFormatException ignore) {
       }
-      if (raw.matches("^\\d+$")) {
-        return Integer.parseInt(raw);
+      try {
+        return new BigDecimal(raw);
+      } catch (NumberFormatException ignore) {
       }
       return raw;
     }

--- a/vertx-config/src/main/java/io/vertx/config/spi/utils/JsonObjectHelper.java
+++ b/vertx-config/src/main/java/io/vertx/config/spi/utils/JsonObjectHelper.java
@@ -21,6 +21,8 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Objects;
 import java.util.Properties;
 
@@ -53,9 +55,9 @@ public class JsonObjectHelper {
       return bool;
     }
 
-    Double integer = asNumber(value);
-    if (integer != null) {
-      return integer;
+    Object number = asNumber(value);
+    if (number != null) {
+      return number;
     }
 
     JsonObject obj = asJsonObject(value);
@@ -71,12 +73,16 @@ public class JsonObjectHelper {
     return value;
   }
 
-  private static Double asNumber(String s) {
+  private static Object asNumber(String s) {
     try {
-      return Double.parseDouble(s);
-    } catch (NumberFormatException nfe) {
-      return null;
+      return new BigInteger(s);
+    } catch (NumberFormatException ignore) {
     }
+    try {
+      return new BigDecimal(s);
+    } catch (NumberFormatException ignore) {
+    }
+    return null;
   }
 
   private static Boolean asBoolean(String s) {

--- a/vertx-config/src/test/java/io/vertx/config/impl/spi/DirectoryConfigStoreTest.java
+++ b/vertx-config/src/test/java/io/vertx/config/impl/spi/DirectoryConfigStoreTest.java
@@ -119,10 +119,14 @@ public class DirectoryConfigStoreTest extends ConfigStoreTestBase {
       JsonObject json = ar.result();
       assertThat(json.getString("key")).isEqualTo("value");
       assertThat(json.getBoolean("true")).isTrue();
+      assertThat(json.getString("true")).isEqualTo("true");
       assertThat(json.getBoolean("false")).isFalse();
+      assertThat(json.getString("false")).isEqualTo("false");
       assertThat(json.getString("missing")).isNull();
       assertThat(json.getInteger("int")).isEqualTo(5);
+      assertThat(json.getString("int")).isEqualTo("5");
       assertThat(json.getDouble("float")).isEqualTo(25.3);
+      assertThat(json.getString("float")).isEqualTo("25.3");
       async.complete();
     });
   }

--- a/vertx-config/src/test/java/io/vertx/config/impl/spi/EnvVariablesConfigStoreWithMockEnvTest.java
+++ b/vertx-config/src/test/java/io/vertx/config/impl/spi/EnvVariablesConfigStoreWithMockEnvTest.java
@@ -74,8 +74,12 @@ public class EnvVariablesConfigStoreWithMockEnvTest extends ConfigStoreTestBase 
 
     retriever.getConfig(ar -> {
       assertThat(ar.succeeded()).isTrue();
-      // Converted value, totally wrong ;-)
-      assertThat(ar.result().getInteger("name")).isEqualTo(2147483647);
+      try {
+        // We don't mind the value (truncated, we just want to make sure it doesn't throw an exception)
+        assertThat(ar.result().getInteger("name")).isNotNull();
+      } catch (ClassCastException e) {
+        throw new AssertionError("Should not throw exception", e);
+      }
       done.set(true);
     });
     await().untilAtomic(done, is(true));

--- a/vertx-config/src/test/java/io/vertx/config/impl/spi/SystemPropertiesConfigStoreWithRawDataTest.java
+++ b/vertx-config/src/test/java/io/vertx/config/impl/spi/SystemPropertiesConfigStoreWithRawDataTest.java
@@ -23,7 +23,6 @@ import io.vertx.config.ConfigStoreOptions;
 import io.vertx.core.json.JsonObject;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -75,8 +74,12 @@ public class SystemPropertiesConfigStoreWithRawDataTest extends ConfigStoreTestB
 
     retriever.getConfig(ar -> {
       assertThat(ar.succeeded()).isTrue();
-      // Converted value, totally wrong ;-)
-      assertThat(ar.result().getInteger("name")).isEqualTo(2147483647);
+      try {
+        // We don't mind the value (truncated, we just want to make sure it doesn't throw an exception)
+        assertThat(ar.result().getInteger("name")).isNotNull();
+      } catch (ClassCastException e) {
+        throw new AssertionError("Should not throw exception", e);
+      }
       done.set(true);
     });
     await().untilAtomic(done, is(true));


### PR DESCRIPTION
When converting from properties to JSON, we should preserve the string representation.

Indeed, users might want to get the value '123456' as a String, and so far we would convert it to Double which led to String value being '123456.0'.

Fixes #124