### PR TITLE
Upgrade typesafe config version

### DIFF
--- a/vertx-config-hocon/pom.xml
+++ b/vertx-config-hocon/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>com.typesafe</groupId>
       <artifactId>config</artifactId>
-      <version>1.3.4</version>
+      <version>1.4.1</version>
     </dependency>
   </dependencies>
 

--- a/vertx-config-spring-config-server/pom.xml
+++ b/vertx-config-spring-config-server/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>com.typesafe</groupId>
       <artifactId>config</artifactId>
-      <version>1.3.4</version>
+      <version>1.4.1</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Otherwise the Vert.x stack convergence tests fail (conflict with Cassandra Client)