### PR TITLE
Updated/removed documentation links

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,8 +9,4 @@ Vert.x Config provide an extensible way to configure Vert.x applications:
 
 Please see the main documentation on the web-site for a full description:
 
-* https://vertx.io/docs/vertx-config/java/[Java documentation]
-* https://vertx.io/docs/vertx-config/js/[JavaScript documentation]
-* https://vertx.io/docs/vertx-config/kotlin/[Kotlin documentation]
-* https://vertx.io/docs/vertx-config/groovy/[Groovy documentation]
-* https://vertx.io/docs/vertx-config/ruby/[Ruby documentation]
+* https://vertx.io/docs/vertx-config/java/[Java/Kotlin/Groovy documentation]


### PR DESCRIPTION
It seems like Kotlin and Groovy developers should use the Java version. JavaScript and Ruby has been moved out or dropped from this project.