### PR TITLE
Remove databind

### DIFF
--- a/vertx-config-yaml/pom.xml
+++ b/vertx-config-yaml/pom.xml
@@ -44,8 +44,9 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.dataformat</groupId>
-      <artifactId>jackson-dataformat-yaml</artifactId>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.30</version>
     </dependency>
   </dependencies>
 </project>

--- a/vertx-config-yaml/src/test/java/io/vertx/config/yaml/YamlProcessorTest.java
+++ b/vertx-config-yaml/src/test/java/io/vertx/config/yaml/YamlProcessorTest.java
@@ -133,7 +133,7 @@ public class YamlProcessorTest {
       expectSuccess(ar);
       JsonObject json = ar.result();
       assertThat(json.getInteger("invoice")).isEqualTo(34843);
-      assertThat(json.getString("date")).isEqualTo("2001-01-23");
+      assertThat(json.getInstant("date").toString()).isEqualTo("2001-01-23T00:00:00Z");
       JsonObject bill = json.getJsonObject("bill-to");
       assertThat(bill).contains(entry("given", "Chris"), entry("family", "Dumars"));
       assertThat(bill.getJsonObject("address")).isNotNull().isNotEmpty();


### PR DESCRIPTION
Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Motivation:

Databind is one of the reasons we need to do some CVE releases. Given that this is internal usage, we can avoid it and just rely on the already used dependency snake yaml