### PR TITLE
Upgrade snakeyaml from 1.30 to 1.31 fixing CVE-2022-25857

### DIFF
--- a/vertx-config-yaml/pom.xml
+++ b/vertx-config-yaml/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.30</version>
+      <version>1.31</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Upgrading org.yaml:snakeyaml from 1.30 to 1.31 in vertx-config-yaml
fixes a Denial of Service (DoS) vulnerability caused by a missing
nested depth limitation for collections.

https://nvd.nist.gov/vuln/detail/CVE-2022-25857