### PR TITLE
[issue-151] Cannot read yaml file from multiple verticles

### DIFF
--- a/vertx-config-yaml/src/main/java/io/vertx/config/yaml/YamlProcessor.java
+++ b/vertx-config-yaml/src/main/java/io/vertx/config/yaml/YamlProcessor.java
@@ -38,8 +38,6 @@ import java.util.Map;
  */
 public class YamlProcessor implements ConfigProcessor {
 
-  private final Yaml yamlMapper = new Yaml(new SafeConstructor());
-
   @Override
   public String name() {
     return "yaml";
@@ -55,6 +53,7 @@ public class YamlProcessor implements ConfigProcessor {
     // Use executeBlocking even if the bytes are in memory
     return vertx.executeBlocking(promise -> {
       try {
+        final Yaml yamlMapper = new Yaml(new SafeConstructor());
         Map<Object, Object> doc = yamlMapper.load(input.toString(StandardCharsets.UTF_8));
         promise.complete(jsonify(doc));
       } catch (ClassCastException e) {

--- a/vertx-config-yaml/src/test/java/io/vertx/config/yaml/YamlMultipleVerticlesTest.java
+++ b/vertx-config-yaml/src/test/java/io/vertx/config/yaml/YamlMultipleVerticlesTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.config.yaml;
+
+import io.vertx.config.ConfigRetriever;
+import io.vertx.config.ConfigRetrieverOptions;
+import io.vertx.config.ConfigStoreOptions;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:aoingl@gmail.com">Lin Gao</a>
+ */
+@RunWith(VertxUnitRunner.class)
+public class YamlMultipleVerticlesTest {
+  private Vertx vertx;
+
+  @Before
+  public void setUp() {
+    vertx = Vertx.vertx();
+  }
+
+  @After
+  public void tearDown() {
+    vertx.close();
+  }
+
+  private static class ConfigYamlVerticle extends AbstractVerticle {
+    private ConfigRetriever retriever;
+
+    @Override
+    public void start(Promise<Void> startPromise) throws Exception {
+      ConfigStoreOptions store = new ConfigStoreOptions()
+        .setType("file")
+        .setFormat("yaml")
+        .setConfig(new JsonObject()
+          .put("path", "src/test/resources/simple.yaml")
+        );
+      retriever = ConfigRetriever.create(vertx,
+        new ConfigRetrieverOptions().addStore(store));
+      retriever.getConfig().onComplete(js -> {
+        if (js.succeeded()) {
+          String value = js.result().getString("key");
+          Assert.assertEquals("value", value);
+          startPromise.complete();
+        } else {
+          startPromise.fail(js.cause());
+        }
+      });
+    }
+
+    @Override
+    public void stop() throws Exception {
+      retriever.close();
+    }
+  }
+
+  @Test
+  public void testReadYamlConcurrent(TestContext testContext) {
+    int instances = 4;
+    vertx.deployVerticle(ConfigYamlVerticle::new, new DeploymentOptions().setInstances(instances))
+      .onComplete(testContext.asyncAssertSuccess(va -> vertx.undeploy(va, testContext.asyncAssertSuccess())));
+  }
+
+}


### PR DESCRIPTION
Motivation:

Fixes #151 

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines


After the change of [removing databind](https://github.com/vert-x3/vertx-config/pull/147), YamlProcessor uses the same Yaml instance for multiple accesses from different threads, however, according to [Yaml javadoc](https://bitbucket.org/snakeyaml/snakeyaml/src/49e794037c6be07053ce930f71f9c31b09180920/src/main/java/org/yaml/snakeyaml/Yaml.java#lines-47), it is not thread safe. So it will lead to errors when reading yaml configs from multiple verticles.

This PR proposes to create a new Yaml instance on each call.