### PR TITLE
[Issue-143] Support system environment variables overrides with HOCON config file format

### DIFF
--- a/vertx-config-hocon/pom.xml
+++ b/vertx-config-hocon/pom.xml
@@ -47,4 +47,28 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <environmentVariables>
+                <CONFIG_FORCE_some__macro>hocon</CONFIG_FORCE_some__macro>
+                <CONFIG_FORCE_int>10</CONFIG_FORCE_int>
+                <CONFIG_FORCE_sub>{"foo": "bar2"}</CONFIG_FORCE_sub>
+              </environmentVariables>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/vertx-config-hocon/src/main/asciidoc/hocon-format.adoc
+++ b/vertx-config-hocon/src/main/asciidoc/hocon-format.adoc
@@ -1,7 +1,7 @@
 === Hocon Configuration Format
 
 The Hocon Configuration Format extends the Vert.x Configuration Retriever and provides the
-support for the HOCON(https://github.com/typesafehub/config/blob/master/HOCON.md) format.
+support for the https://github.com/lightbend/config/blob/master/HOCON.md[HOCON] format.
 
 It supports includes, json, properties, macros...
 
@@ -45,3 +45,12 @@ Once added to your classpath or dependencies, you need to configure the
 ----
 
 You just need to set `format` to `hocon`.
+
+==== Override configuration using system environment variables
+
+Hocon supports https://github.com/lightbend/config#optional-system-or-env-variable-overrides[system environment variable overrides] using keys with `CONFIG_FORCE_` prefix. You can use this feature by specifying `hocon.env.override` to `true` in the configuration:
+
+[source, $lang]
+----
+{@link examples.ConfigHoconExamples#exampleWithEnvOverrides(io.vertx.core.Vertx)}
+----

--- a/vertx-config-hocon/src/main/java/examples/ConfigHoconExamples.java
+++ b/vertx-config-hocon/src/main/java/examples/ConfigHoconExamples.java
@@ -41,5 +41,17 @@ public class ConfigHoconExamples {
         new ConfigRetrieverOptions().addStore(store));
   }
 
+  public void exampleWithEnvOverrides(Vertx vertx) {
+    ConfigStoreOptions store = new ConfigStoreOptions()
+      .setType("file")
+      .setFormat("hocon")
+      .setConfig(new JsonObject()
+        .put("hocon.env.override", true)
+        .put("path", "my-config.conf")
+      );
+
+    ConfigRetriever retriever = ConfigRetriever.create(vertx,
+      new ConfigRetrieverOptions().addStore(store));
+  }
 
 }


### PR DESCRIPTION
Fixes: #143 

This PR tries to add a configuration `hocon.env.override` to HoconProcessor to indicate if it will try to read configuration from system environment variables to override the existing ones.

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines


