### PR TITLE
Add hierarchical environment variables

### DIFF
--- a/vertx-config/src/main/asciidoc/index.adoc
+++ b/vertx-config/src/main/asciidoc/index.adoc
@@ -217,6 +217,15 @@ must be listed individually:
 {@link examples.ConfigExamples#env3()}
 ----
 
+Furthermore, there is the `hierarchical` attribute (`false` by default). If `hierarchical` is `true`, the environment variables will be parsed as a nested JSON object, using the dot-separated property name as the path in the JSON object.
+
+Example:
+
+[source, $lang]
+----
+{@link examples.ConfigExamples#envHierarchical()}
+----
+
 === System Properties
 
 This configuration store transforms system properties to a JSON Object contributed to the

--- a/vertx-config/src/main/java/examples/ConfigExamples.java
+++ b/vertx-config/src/main/java/examples/ConfigExamples.java
@@ -129,6 +129,11 @@ public class ConfigExamples {
       .setConfig(new JsonObject().put("keys", new JsonArray().add("SERVICE1_HOST").add("SERVICE2_HOST")));
   }
 
+  public void envHierarchical() {
+    ConfigStoreOptions envHierarchical = new ConfigStoreOptions()
+      .setType("env")
+      .setConfig(new JsonObject().put("hierarchical", true));
+  }
 
   public void http() {
     ConfigStoreOptions http = new ConfigStoreOptions()

--- a/vertx-config/src/main/java/io/vertx/config/impl/spi/EnvVariablesConfigStoreFactory.java
+++ b/vertx-config/src/main/java/io/vertx/config/impl/spi/EnvVariablesConfigStoreFactory.java
@@ -49,6 +49,6 @@ public class EnvVariablesConfigStoreFactory implements ConfigStoreFactory {
 
   @Override
   public ConfigStore create(Vertx vertx, JsonObject configuration) {
-    return new EnvVariablesConfigStore(vertx, configuration.getBoolean("raw-data", false), configuration.getJsonArray("keys"), getenv);
+    return new EnvVariablesConfigStore(vertx, configuration.getBoolean("raw-data", false), configuration.getBoolean("hierarchical", false), configuration.getJsonArray("keys"), getenv);
   }
 }

--- a/vertx-config/src/main/java/io/vertx/config/spi/utils/JsonObjectHelper.java
+++ b/vertx-config/src/main/java/io/vertx/config/spi/utils/JsonObjectHelper.java
@@ -49,6 +49,27 @@ public class JsonObjectHelper {
     json.put(name, rawData ? value : convert(value));
   }
 
+  public static void put(JsonObject json, String name, String value, boolean rawData, boolean hierarchical) {
+    if (!hierarchical) {
+      put(json, name, value, rawData);
+    } else {
+      List<String> path = Arrays.asList(name.split("\\."));
+      if (path.size() == 1) {
+        put(json, name, value, rawData);
+      } else {
+        JsonObject current = json;
+        for (int i = 0; i < path.size() - 1; i++) {
+          String key = path.get(i);
+          if (!current.containsKey(key)) {
+            current.put(key, new JsonObject());
+          }
+          current = current.getJsonObject(key);
+        }
+        put(current, path.get(path.size() - 1), value, rawData);
+      }
+    }
+  }
+
   public static Object convert(String value) {
     Objects.requireNonNull(value);
 

--- a/vertx-config/src/test/java/io/vertx/config/impl/spi/MockEnvVariablesConfigStoreFactory.java
+++ b/vertx-config/src/test/java/io/vertx/config/impl/spi/MockEnvVariablesConfigStoreFactory.java
@@ -44,7 +44,7 @@ public class MockEnvVariablesConfigStoreFactory implements ConfigStoreFactory {
   @Override
   public ConfigStore create(Vertx vertx, JsonObject configuration) {
     JsonObject envConfig = configuration.getJsonObject("env");
-    return new EnvVariablesConfigStore(vertx, configuration.getBoolean("raw-data", false), configuration.getJsonArray("keys"), () -> {
+    return new EnvVariablesConfigStore(vertx, configuration.getBoolean("raw-data", false), configuration.getBoolean("hierarchical", false), configuration.getJsonArray("keys"), () -> {
       Map<String, String> env = new HashMap<>(System.getenv());
       if (envConfig != null) {
         for (Map.Entry entry : envConfig) {


### PR DESCRIPTION
Motivation:

As in #135 that introduced hierarchical system properties, the motivation here is to implement hierarchical environment variables separated by dots. This allows environment variables to be converted into JSON objects.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
