### PR TITLE
fix issue: RefNotFoundException is thrown when changing the git branch when using vertx-config-git #165

### DIFF
--- a/vertx-config-git/src/main/java/io/vertx/config/git/GitConfigStore.java
+++ b/vertx-config-git/src/main/java/io/vertx/config/git/GitConfigStore.java
@@ -142,9 +142,13 @@ public class GitConfigStore implements ConfigStore {
         }
         return git;
       } else {
+        boolean hasBranch = git.branchList()
+          .call()
+          .stream()
+          .anyMatch(b -> b.getName().equals("refs/heads/" + branch));
         git.checkout()
           .setName(branch)
-          .setCreateBranch(true)
+          .setCreateBranch(!hasBranch)
           .setUpstreamMode(CreateBranchCommand.SetupUpstreamMode.TRACK)
           .setStartPoint(remote + "/" + branch)
           .call();

--- a/vertx-config-git/src/main/java/io/vertx/config/git/GitConfigStore.java
+++ b/vertx-config-git/src/main/java/io/vertx/config/git/GitConfigStore.java
@@ -144,6 +144,7 @@ public class GitConfigStore implements ConfigStore {
       } else {
         git.checkout()
           .setName(branch)
+          .setCreateBranch(true)
           .setUpstreamMode(CreateBranchCommand.SetupUpstreamMode.TRACK)
           .setStartPoint(remote + "/" + branch)
           .call();


### PR DESCRIPTION
fix issue: RefNotFoundException is thrown when changing the git branch when using vertx-config-git #165