### PR TITLE
Fix intermittent failures

### DIFF
--- a/vertx-config/src/test/java/io/vertx/config/tests/ScanAndBroadcastTest.java
+++ b/vertx-config/src/test/java/io/vertx/config/tests/ScanAndBroadcastTest.java
@@ -74,7 +74,9 @@ public class ScanAndBroadcastTest {
 
   @After
   public void tearDown() throws Exception {
-    retriever.close();
+    if (retriever != null) {
+      retriever.close();
+    }
     vertx.close().await(20, TimeUnit.SECONDS);
   }
 

--- a/vertx-config/src/test/java/io/vertx/config/tests/verticle/VerticleDeploymentTest.java
+++ b/vertx-config/src/test/java/io/vertx/config/tests/verticle/VerticleDeploymentTest.java
@@ -17,6 +17,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.concurrent.TimeUnit;
+
 @RunWith(VertxUnitRunner.class)
 public class VerticleDeploymentTest {
 
@@ -31,8 +33,8 @@ public class VerticleDeploymentTest {
   }
 
   @After
-  public void tearDown() {
-    vertx.close();
+  public void tearDown() throws Exception {
+    vertx.close().await(20, TimeUnit.SECONDS);
   }
 
   @Test


### PR DESCRIPTION
In CI, ScanAndBroadcastTest failed with java.net.BindException: Address already in use.

It ran after VerticleDeploymentTest, which does not wait for the close sequence to complete. This could explain the exception.

Besides, if a problem happens in one of the ScanAndBroadcastTest tests, a NPE is thrown in the tear down method because the retriever may not be initialized.