### PR TITLE
Add spotless plugin and remove unused imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,16 @@
     </pluginManagement>
     <plugins>
       <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <java>
+            <removeUnusedImports />
+          </java>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>

--- a/vertx-config-kubernetes-configmap/src/test/java/io/vertx/config/kubernetes/tests/ConfigMapStoreOpenShiftTest.java
+++ b/vertx-config-kubernetes-configmap/src/test/java/io/vertx/config/kubernetes/tests/ConfigMapStoreOpenShiftTest.java
@@ -32,7 +32,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>

--- a/vertx-config-spring-config-server/src/main/java/io/vertx/config/spring/SpringConfigServerStore.java
+++ b/vertx-config-spring-config-server/src/main/java/io/vertx/config/spring/SpringConfigServerStore.java
@@ -25,7 +25,6 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpResponseExpectation;
 import io.vertx.core.http.RequestOptions;
-import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 

--- a/vertx-config-vault/src/main/java/io/vertx/config/vault/client/Auth.java
+++ b/vertx-config-vault/src/main/java/io/vertx/config/vault/client/Auth.java
@@ -22,7 +22,6 @@ import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonObject;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Represents Auth result.

--- a/vertx-config-vault/src/main/java/io/vertx/config/vault/client/Secret.java
+++ b/vertx-config-vault/src/main/java/io/vertx/config/vault/client/Secret.java
@@ -21,8 +21,6 @@ import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonObject;
 
-import java.util.Map;
-
 /**
  * Represent Secret result.
  *

--- a/vertx-config-vault/src/test/java/io/vertx/config/vault/tests/VaultConfigStoreTestBase.java
+++ b/vertx-config-vault/src/test/java/io/vertx/config/vault/tests/VaultConfigStoreTestBase.java
@@ -38,10 +38,8 @@ import org.junit.runner.RunWith;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertTrue;
 
 /**

--- a/vertx-config-vault/src/test/java/io/vertx/config/vault/tests/utils/VaultProcess.java
+++ b/vertx-config-vault/src/test/java/io/vertx/config/vault/tests/utils/VaultProcess.java
@@ -32,7 +32,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import static io.vertx.config.vault.tests.VaultConfigStoreTestBase.awaitUntil;
-import static org.hamcrest.core.Is.is;
 
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>

--- a/vertx-config/src/main/java/io/vertx/config/ConfigRetriever.java
+++ b/vertx-config/src/main/java/io/vertx/config/ConfigRetriever.java
@@ -22,7 +22,6 @@ import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.VertxGen;
 import io.vertx.config.impl.ConfigRetrieverImpl;
 import io.vertx.config.spi.ConfigStore;
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;

--- a/vertx-config/src/main/java/io/vertx/config/spi/ConfigStore.java
+++ b/vertx-config/src/main/java/io/vertx/config/spi/ConfigStore.java
@@ -17,9 +17,7 @@
 
 package io.vertx.config.spi;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 
 /**

--- a/vertx-config/src/test/java/io/vertx/config/tests/verticle/VerticleRedeploymentTest.java
+++ b/vertx-config/src/test/java/io/vertx/config/tests/verticle/VerticleRedeploymentTest.java
@@ -28,8 +28,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingDeque;
-import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
Added spotless plugin to remove unused imports. I have just added the goal of removing unused imports, this can be further extended to impose a code style, import order etc.

cc @vietj I believe this will help with checks. You can use goal = `spotless:apply` to remove unused imports now.